### PR TITLE
Allow updating previous answers

### DIFF
--- a/src/questions.rs
+++ b/src/questions.rs
@@ -228,6 +228,8 @@ pub(crate) fn questions_submit(
     backend: State<Arc<Mutex<NoriaBackend>>>,
     config: State<Config>,
 ) -> Redirect {
+    use noria::Modification;
+
     let mut bg = backend.lock().unwrap();
 
     let num: DataType = (num as u64).into();
@@ -243,7 +245,15 @@ pub(crate) fn questions_submit(
             answer.clone().into(),
             ts.clone(),
         ];
-        table.insert(rec).expect("failed to write answer!");
+        table
+            .insert_or_update(
+                rec,
+                vec![
+                    (3, Modification::Set(answer.clone().into())),
+                    (4, Modification::Set(ts.clone())),
+                ],
+            )
+            .expect("failed to write answer!");
     }
 
     if config.send_emails {

--- a/templates/questions.hbs
+++ b/templates/questions.hbs
@@ -5,7 +5,10 @@
       {{#each questions}}
       <label>{{{ this.prompt }}}:
         <p>
-        <textarea name="q_{{{ this.id }}}" rows="10" cols="80">Write something here.</textarea>
+        <textarea name="q_{{{ this.id }}}" rows="10" cols="80"
+         {{#if this.answer}} disabled
+         {{else}} placeholder="Write something here."
+         {{/if}}>{{{ this.answer }}}</textarea>
         </p>
       </label>
       {{/each}}

--- a/templates/questions.hbs
+++ b/templates/questions.hbs
@@ -6,7 +6,7 @@
       <label>{{{ this.prompt }}}:
         <p>
         <textarea name="q_{{{ this.id }}}" rows="10" cols="80"
-         {{#if this.answer}} disabled
+         {{#if this.answer}}
          {{else}} placeholder="Write something here."
          {{/if}}>{{{ this.answer }}}</textarea>
         </p>


### PR DESCRIPTION
Use `insert_or_update` to update previous answers.

Note that the colum IDs (3 = answer text, 4 = date) will need changing to work with the user shard schema, since that lacks the user ID column, I believe.